### PR TITLE
feat: Create Discord music bot with web admin panel

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,1 @@
+# This file can be empty

--- a/bot/cogs/__init__.py
+++ b/bot/cogs/__init__.py
@@ -1,0 +1,1 @@
+# This file can be empty

--- a/bot/cogs/music.py
+++ b/bot/cogs/music.py
@@ -1,0 +1,100 @@
+import discord
+from discord.ext import commands
+import yt_dlp
+import asyncio
+from bot.utils import load_config
+
+# Suppress noise about console usage from errors
+yt_dlp.utils.bug_reports_message = lambda: ''
+
+ytdl_format_options = {
+    'format': 'bestaudio/best',
+    'outtmpl': '%(extractor)s-%(id)s-%(title)s.%(ext)s',
+    'restrictfilenames': True,
+    'noplaylist': True,
+    'nocheckcertificate': True,
+    'ignoreerrors': False,
+    'logtostderr': False,
+    'quiet': True,
+    'no_warnings': True,
+    'default_search': 'auto',
+    'source_address': '0.0.0.0',  # bind to ipv4 since ipv6 addresses cause issues sometimes
+}
+
+ffmpeg_options = {
+    'options': '-vn',
+}
+
+ytdl = yt_dlp.YoutubeDL(ytdl_format_options)
+
+class YTDLSource(discord.PCMVolumeTransformer):
+    def __init__(self, source, *, data, volume=0.5):
+        super().__init__(source, volume)
+        self.data = data
+        self.title = data.get('title')
+        self.url = data.get('url')
+
+    @classmethod
+async def from_url(cls, url, *, loop=None, stream=False):
+        loop = loop or asyncio.get_event_loop()
+        data = await loop.run_in_executor(None, lambda: ytdl.extract_info(url, download=not stream))
+        if 'entries' in data:
+            # take first item from a playlist
+            data = data['entries'][0]
+        filename = data['url'] if stream else ytdl.prepare_filename(data)
+        return cls(discord.FFmpegPCMAudio(filename, **ffmpeg_options), data=data)
+
+
+class Music(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.config = load_config()
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if message.author.bot:
+            return
+
+        self.config = load_config()
+        text_channel_id = self.config.get("TEXT_CHANNEL_ID")
+        voice_channel_id = self.config.get("VOICE_CHANNEL_ID")
+
+        if not text_channel_id or not voice_channel_id:
+            return
+
+        if message.channel.id != int(text_channel_id):
+            return
+
+        # Simple check for youtube url
+        if 'youtube.com/watch' in message.content or 'youtu.be/' in message.content:
+            voice_channel = self.bot.get_channel(int(voice_channel_id))
+            if not voice_channel:
+                await message.channel.send("Configured voice channel not found.")
+                return
+
+            # Connect to voice channel if not already connected
+            if not message.guild.voice_client:
+                await voice_channel.connect()
+            elif message.guild.voice_client.channel != voice_channel:
+                await message.guild.voice_client.move_to(voice_channel)
+
+            await self.play_song(message, message.content)
+
+    async def play_song(self, ctx, url):
+        """Streams from a url (same as yt, but doesn't predownload)"""
+        if ctx.guild.voice_client.is_playing():
+             ctx.guild.voice_client.stop()
+
+        async with ctx.channel.typing():
+            try:
+                player = await YTDLSource.from_url(url, loop=self.bot.loop, stream=True)
+                ctx.guild.voice_client.play(player, after=lambda e: print(f'Player error: {e}') if e else None)
+                await ctx.channel.send(f'Now playing: {player.title}')
+                ctx.guild.voice_client.source.volume = self.config.get("VOLUME", 0.5)
+
+            except Exception as e:
+                await ctx.channel.send(f"An error occurred: {e}")
+
+
+async def setup(bot):
+    await bot.add_cog(Music(bot))

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,57 @@
+import discord
+from discord.ext import commands
+import json
+import os
+import asyncio
+from bot.utils import load_config
+
+# Get the absolute path to the project's root directory
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+# Construct the absolute path to config.json
+config_path = os.path.join(project_root, 'config.json')
+
+config = load_config()
+BOT_TOKEN = config.get("BOT_TOKEN")
+
+intents = discord.Intents.default()
+intents.message_content = True
+intents.voice_states = True
+
+bot = commands.Bot(command_prefix="!", intents=intents)
+
+@bot.event
+async def on_ready():
+    print(f'Logged in as {bot.user.name}')
+    print('------')
+
+@bot.command()
+async def ping(ctx):
+    """Responds with 'Pong!'"""
+    await ctx.send('Pong!')
+
+async def load_cogs():
+    """Loads all cogs from the cogs directory."""
+    for filename in os.listdir(os.path.join(project_root, 'bot/cogs')):
+        if filename.endswith('.py') and not filename.startswith('__'):
+            try:
+                await bot.load_extension(f'bot.cogs.{filename[:-3]}')
+                print(f'Loaded cog: {filename[:-3]}')
+            except Exception as e:
+                print(f'Failed to load cog {filename[:-3]}: {e}')
+
+def run_bot():
+    if BOT_TOKEN == "YOUR_BOT_TOKEN_HERE" or not BOT_TOKEN:
+        print("Error: Bot token is not configured. Please add it to config.json.")
+        return
+
+    async def runner():
+        async with bot:
+            await load_cogs()
+            await bot.start(BOT_TOKEN)
+
+    asyncio.run(runner())
+
+
+if __name__ == "__main__":
+    run_bot()

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,18 @@
+import json
+import os
+
+# Get the absolute path to the project's root directory
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+# Construct the absolute path to config.json
+config_path = os.path.join(project_root, 'config.json')
+
+def load_config():
+    """Loads the configuration from config.json."""
+    with open(config_path, 'r') as f:
+        return json.load(f)
+
+def save_config(config):
+    """Saves the configuration to config.json."""
+    with open(config_path, 'w') as f:
+        json.dump(config, f, indent=4)

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+    "BOT_TOKEN": "YOUR_BOT_TOKEN_HERE",
+    "TEXT_CHANNEL_ID": null,
+    "VOICE_CHANNEL_ID": null,
+    "VOLUME": 0.5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+discord.py
+Flask
+yt-dlp
+ffmpeg-python

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,40 @@
+@echo off
+TITLE Discord Music Bot
+
+ECHO ==================================================
+ECHO  Starting Discord Music Bot and Admin Panel
+ECHO ==================================================
+
+REM Check for Python
+python --version >nul 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO Python is not installed or not in PATH.
+    ECHO Please install Python 3.8+ and add it to your PATH.
+    pause
+    exit /b
+)
+
+REM Create a virtual environment if it doesn't exist
+IF NOT EXIST .venv (
+    ECHO Creating virtual environment...
+    python -m venv .venv
+)
+
+ECHO Activating virtual environment...
+CALL .venv\Scripts\activate.bat
+
+ECHO Installing dependencies from requirements.txt...
+pip install -r requirements.txt
+
+ECHO ==================================================
+ECHO  Launching Bot and Web Server...
+ECHO  Admin Panel will be available at http://localhost:5000
+ECHO ==================================================
+
+REM Start the web server in a new window
+start "Admin Panel" cmd /c "python web/app.py"
+
+REM Start the Discord bot in the current window
+python bot/main.py
+
+pause

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,0 +1,1 @@
+# This file can be empty

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,37 @@
+from flask import Flask, render_template, request, jsonify, redirect, url_for
+import os
+import sys
+
+# Add the project root to the Python path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, project_root)
+
+from bot.utils import load_config, save_config
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        new_config = {
+            "BOT_TOKEN": load_config().get("BOT_TOKEN"), # Preserve the token
+            "TEXT_CHANNEL_ID": request.form.get('text_channel_id'),
+            "VOICE_CHANNEL_ID": request.form.get('voice_channel_id'),
+            "VOLUME": float(request.form.get('volume'))
+        }
+        save_config(new_config)
+        return redirect(url_for('index'))
+
+    config = load_config()
+    return render_template('index.html', config=config)
+
+@app.route('/api/config', methods=['GET'])
+def api_config():
+    config = load_config()
+    return jsonify(config)
+
+def run_web_server():
+    app.run(host='0.0.0.0', port=5000)
+
+if __name__ == '__main__':
+    run_web_server()

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -1,0 +1,1 @@
+/* Custom styles */

--- a/web/static/js/script.js
+++ b/web/static/js/script.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', (event) => {
+    const volumeSlider = document.getElementById('volume');
+    const volumeValue = document.getElementById('volume-value');
+
+    if (volumeSlider && volumeValue) {
+        volumeSlider.addEventListener('input', () => {
+            volumeValue.textContent = volumeSlider.value;
+        });
+    }
+});

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Discord Bot Admin Panel</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    <div class="container mt-5">
+        <h1 class="mb-4">Discord Music Bot - Admin Panel</h1>
+
+        <div class="card">
+            <div class="card-body">
+                <h5 class="card-title">Bot Settings</h5>
+                <form action="/" method="POST">
+                    <div class="mb-3">
+                        <label for="text_channel_id" class="form-label">Text Channel ID</label>
+                        <input type="text" class="form-control" id="text_channel_id" name="text_channel_id" value="{{ config.TEXT_CHANNEL_ID }}">
+                    </div>
+                    <div class="mb-3">
+                        <label for="voice_channel_id" class="form-label">Voice Channel ID</label>
+                        <input type="text" class="form-control" id="voice_channel_id" name="voice_channel_id" value="{{ config.VOICE_CHANNEL_ID }}">
+                    </div>
+                    <div class="mb-3">
+                        <label for="volume" class="form-label">Volume: <span id="volume-value">{{ config.VOLUME }}</span></label>
+                        <input type="range" class="form-range" id="volume" name="volume" min="0.0" max="2.0" step="0.05" value="{{ config.VOLUME }}">
+                    </div>
+                    <button type="submit" class="btn btn-primary">Save Settings</button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <script src="{{ url_for('static', filename='js/script.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a new Discord music bot with a web-based admin panel.

The bot can play music from YouTube links posted in a designated text channel. The admin panel allows for configuration of the bot's settings, including volume, text channel, and voice channel.

A 'start.bat' script is included for easy local setup and execution.